### PR TITLE
Version 2.1: Feature row status highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Sample configuration file provided in `sample.env`
 - `LABOR_MODE_CUSTOM_NAMING=123456:Event,234567:Office`
 
   Naming to differentiate When I Work locations from each other when using the 'LABOR' layout, which has shifts in a condensed form.
+  
+- `EMS_Status_ROW_HIGHLIGHT=2:#ffffff50,3:#aabbccdd`
+
+  Set row highlight colors (HEXA) (hex w/ alpha) associated event status ID (ID first). Applies to EMS event date list only. Separate each state setting from the color value by commas (`,`). Separate status ID and color code by colons (`:`).
 
 ## Updates
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "when-i-work-events-shifts-display",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Shift display for Events Services, pulling data from the When I Work API",
   "main": "main.js",
   "scripts": {

--- a/sample.env
+++ b/sample.env
@@ -29,3 +29,5 @@ EMS_BUILDINGS=1,2,3,4
 EMS_STATUSES=2,3,4,5
 EMS_EVENT_TYPES=1,2,3,4,5,6,7,8,9
 LABOR_MODE_CUSTOM_NAMING=123456:events,234567:office
+# Set row highlight colors (HEXA) (hex w/ alpha) associated event status ID (ID first)
+EMS_Status_ROW_HIGHLIGHT=2:#ffffff50,3:#aabbccdd

--- a/templates/eventDateCard.pug
+++ b/templates/eventDateCard.pug
@@ -6,7 +6,7 @@ div(class='card m-1 p-0 d-inline-block w-100')
       tbody
         each event in events
           if event.now
-            tr.font-weight-bold.shift-item
+            tr(style=`background-color: ${event.highlight ? event.highlight : '#00000000'}`).font-weight-bold.shift-item
               td.room-code #{event.room}
               td.text-truncate.event-title #{event.title}
               td.time-width #{event.bookStart}
@@ -14,7 +14,7 @@ div(class='card m-1 p-0 d-inline-block w-100')
               td.time-width #{event.eventEnd}
               td.time-width #{event.bookEnd}
           else
-            tr.shift-item
+            tr(style=`background-color: ${event.highlight ? event.highlight : '#00000000'}`).shift-item
               td.room-code #{event.room}
               td.text-truncate.event-title #{event.title}
               td.time-width #{event.bookStart}

--- a/utils/fetchEmsSchedule.js
+++ b/utils/fetchEmsSchedule.js
@@ -60,9 +60,10 @@ function parseDataForDisplay(xmlHell) {
     try {
       const bookStart = bookingElements.getElementsByTagName('TimeBookingStart')[0].innerHTML;
       return {
-        eventDateIdentity: moment(bookStart).format('ddd, MMM Do'),
+        eventDateIdentity: moment(bookStart).format('ddd MMM Do'),
         eventName: bookingElements.getElementsByTagName('EventName')[0].innerHTML,
         room: bookingElements.getElementsByTagName('RoomCode')[0].innerHTML,
+        eventStatusId: bookingElements.getElementsByTagName('StatusID')[0].innerHTML,
         bookStart,
         eventStart: bookingElements.getElementsByTagName('TimeEventStart')[0].innerHTML,
         eventEnd: bookingElements.getElementsByTagName('TimeEventEnd')[0].innerHTML,

--- a/utils/renderEventList.js
+++ b/utils/renderEventList.js
@@ -7,6 +7,17 @@ const pug = require('pug');
 
 const eventDateCardTemplate = pug.compileFile('./templates/eventDateCard.pug');
 
+let highlight = null;
+if (process.env.EMS_STATUS_ROW_HIGHLIGHT) {
+  highlight = new Map();
+  const highlightArr = process.env.EMS_STATUS_ROW_HIGHLIGHT.split(',');
+  highlightArr.forEach((config) => {
+    const key = config.split(':')[0];
+    const color = config.split(':')[1];
+    highlight.set(key, color);
+  });
+}
+
 /**
  *
  *
@@ -35,6 +46,7 @@ function markupResults(data) {
       eventStart: formatTimes(event.eventStart),
       eventEnd: formatTimes(event.eventEnd),
       bookEnd: formatTimes(event.bookEnd),
+      highlight: highlight ? highlight.get(event.eventStatusId) : null,
     };
   }
 


### PR DESCRIPTION
Adds configurable row status highlight for tables using the ems date card.

Color is configured via environment variable in the format: `ID:#COLOR` such as `2:#FFFFFF50` for status ID 2 and a full white highlight, but with a 50 alpha.

If no colors are configured, or if there is no color configured for a particular status ID, the layout will default to a fully transparent highlight.